### PR TITLE
ValueError: invalid literal for int() with base 10: "2'A=0"

### DIFF
--- a/ecolex/xviews.py
+++ b/ecolex/xviews.py
@@ -239,7 +239,11 @@ class RelatedObjectsView(PagedViewMixin, DetailsView):
             raise Http404()
 
         page = self.request.GET.get('xpage', 1)
-        page = int(page) if page != 'None' else 1
+
+        try:
+            page = int(page) if page != 'None' else 1
+        except ValueError:
+            page = 1
 
         lookups = {doc._resolve_field(remote_field, self.related_type): value}
 


### PR DESCRIPTION
https://sentry.io/iucn-ecolex/ecolex/issues/243404783/

```
ValueError: invalid literal for int() with base 10: "2'A=0"
(1 additional frame(s) were not displayed)
...
  File "django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "ecolex/xviews.py", line 161, in get
    context = self.get_context_data(**kwargs)
  File "ecolex/xviews.py", line 240, in get_context_data
    page = int(page) if page != 'None' else 1

ValueError: invalid literal for int() with base 10: "2'A=0"
```