### PR TITLE
KeyError: 'rss'

### DIFF
--- a/ecolex/search.py
+++ b/ecolex/search.py
@@ -448,9 +448,10 @@ class SearchMixin(object):
             'docDate': (data['yearmin'], data['yearmax']),
         }
         for doc_type in filters['type']:
-            mapping = defs.DOC_TYPE_FILTER_MAPPING[doc_type]
-            for k, v in mapping.items():
-                filters[k] = data[v]
+            if doc_type in defs.DOC_TYPE_FILTER_MAPPING:
+                mapping = defs.DOC_TYPE_FILTER_MAPPING[doc_type]
+                for k, v in mapping.items():
+                    filters[k] = data[v]
 
         # add exclusion local param for OR-able fields
         for field in defs._OR_OP_FACETS:


### PR DESCRIPTION
https://sentry.io/iucn-ecolex/ecolex/issues/289028096/

```
KeyError: 'rss'
(4 additional frame(s) were not displayed)
...
  File "django/views/generic/base.py", line 157, in get
    context = self.get_context_data(**kwargs)
  File "ecolex/views.py", line 65, in get_context_data
    ctx = super(Homepage, self).get_context_data(**kwargs)
  File "ecolex/views.py", line 34, in get_context_data
    self._prepare(self.request.GET)
  File "ecolex/search.py", line 496, in _prepare
    self.filters = self._get_filters(data)
  File "ecolex/search.py", line 451, in _get_filters
    mapping = defs.DOC_TYPE_FILTER_MAPPING[doc_type]

KeyError: 'rss'
```