### PR TITLE
Use stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6-slim-stretch
 
 # roles:
 #   front - publishes ports to the world; this depends on run/docker-compose though...


### PR DESCRIPTION
`python:3.6-slim` uses Debian "stable", which is now "buster", and some
apt packages have gone.